### PR TITLE
fix(node): remove deviceId from PUT payload and add hwSetId support

### DIFF
--- a/internal/provider/node_resource.go
+++ b/internal/provider/node_resource.go
@@ -55,6 +55,7 @@ type NodeResourceModel struct {
 	ModelName    types.String `tfsdk:"model_name"`
 	SerialNumber types.String `tfsdk:"serial_number"`
 	DeviceId     types.String `tfsdk:"device_id"`
+	HwSetId      types.String `tfsdk:"hardware_set_id"`
 	Position     types.String `tfsdk:"position"`
 	Roles        types.Set    `tfsdk:"roles"`
 	Metadata     types.Object `tfsdk:"metadata"`
@@ -74,6 +75,7 @@ func getEmptyNodeResourceModel() *NodeResourceModel {
 		ModelName:    basetypes.NewStringNull(),
 		SerialNumber: basetypes.NewStringNull(),
 		DeviceId:     basetypes.NewStringNull(),
+		HwSetId:      basetypes.NewStringNull(),
 		Position:     basetypes.NewStringNull(),
 		Roles:        basetypes.NewSetNull(SetStringResourceModelAttributeType()),
 		Metadata:     basetypes.NewObjectNull(MetadataResourceModelAttributeType()),
@@ -123,6 +125,10 @@ func getNewNodeResourceModelFromData(data *NodeResourceModel) *NodeResourceModel
 
 	if !data.DeviceId.IsNull() && !data.DeviceId.IsUnknown() {
 		newNode.DeviceId = data.DeviceId
+	}
+
+	if !data.HwSetId.IsNull() && !data.HwSetId.IsUnknown() {
+		newNode.HwSetId = data.HwSetId
 	}
 
 	if !data.Position.IsNull() && !data.Position.IsUnknown() {
@@ -230,6 +236,13 @@ func (r *NodeResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			},
 			"device_id": schema.StringAttribute{
 				MarkdownDescription: "`device_id` defines the unique identifier of the device associated with the Node.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"hardware_set_id": schema.StringAttribute{
+				MarkdownDescription: "`hardware_set_id` defines the unique identifier of the hardware set associated with the Node.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -467,6 +480,8 @@ func getAndSetNodeAttributes(ctx context.Context, diags *diag.Diagnostics, clien
 				newNode.DeviceId = basetypes.NewStringValue(attributeValue.(string))
 				// } else if attributeName == "position" {
 				// 	newNode.Position = basetypes.NewStringValue(attributeValue.(string))
+			} else if attributeName == "hwSetId" {
+				newNode.HwSetId = basetypes.NewStringValue(attributeValue.(string))
 			} else if attributeName == "roles" {
 				newNode.Roles = NewSetString(ctx, attributeValue.([]interface{}))
 			} else if attributeName == "metadata" {
@@ -512,9 +527,13 @@ func getNodeJsonPayload(ctx context.Context, diags *diag.Diagnostics, data *Node
 	if !data.SerialNumber.IsNull() && !data.SerialNumber.IsUnknown() {
 		payloadMap["serialNumber"] = data.SerialNumber.ValueString()
 	}
+	// REMOVE DeviceId from payload on PUT requests
+	// if !data.DeviceId.IsNull() && !data.DeviceId.IsUnknown() {
+	// 	payloadMap["deviceId"] = data.DeviceId.ValueString()
+	// }
 
-	if !data.DeviceId.IsNull() && !data.DeviceId.IsUnknown() {
-		payloadMap["deviceId"] = data.DeviceId.ValueString()
+	if !data.HwSetId.IsNull() && !data.HwSetId.IsUnknown() {
+		payloadMap["hwSetId"] = data.HwSetId.ValueString()
 	}
 
 	if !data.Roles.IsNull() && !data.Roles.IsUnknown() {


### PR DESCRIPTION
## Problem

When updating a `hyperfabric_node` resource (e.g., changing the `description`), the provider was sending `deviceId` in the PUT request body. The fabric node is defined but no device bound in the test case, updating the node in the blueprint design. The Hyperfabric API rejects this with a `400 Bad Request` error:

```
"message": "must not specify reserved MAC address de-ad-00-03-6c-83",
"field": "deviceId",
"errCode": "ERR_CODE_INVALID_VALUE"
```

The `deviceId` field is assigned by the API when a node is initially provisioned. The computed/generated deviceId is reports a Reserved MAC address breaking subsequent updates. Because the provider was including it unconditionally in the JSON payload of every PUT request, any update to a node — even a simple description change — would fail with a 400 error.

## Root Cause

In `getNodeJsonPayload()`, the provider included `deviceId` in the payload whenever it was known and non-null. Since `deviceId` is always populated from the GET response and stored in state, it was always present on subsequent PUT requests:

```golang
// Before (broken)
if !data.DeviceId.IsNull() && !data.DeviceId.IsUnknown() {
    payloadMap["deviceId"] = data.DeviceId.ValueString()
}
```

## Fix

* Removed `deviceId` from the PUT payload. The field is computed/read-only from the API's perspective on updates; it should only be sent on initial `POST` (create).
* Commented out for evaluation and future changes.
* Added `hwSetId` as a computed, read-only attribute (`hardware_set_id` in Terraform schema). The GET response includes `hwSetId` and the API requires it on PUT requests to correctly identify the hardware configuration. This attribute is populated from the GET response and included in update payloads using `UseStateForUnknown` plan modifier to avoid unnecessary diffs.

## Testing

Reproduce by creating a node and then changing `description`. Before this fix the provider returned:

```
Error: 400 Bad Request - must not specify reserved MAC address <deviceId>
```

After this fix the PUT succeeds with only the valid mutable fields in the payload.

## Trace Evidence

GET response (before update): `deviceId` is present and populated from the API.

PUT request (before fix): `deviceId` was echoed back in the request body, triggering `ERR_CODE_INVALID_VALUE`.

PUT request (after fix): `deviceId` is omitted; `hwSetId` is included instead, which the API accepts.
